### PR TITLE
Fixes to connection errors and disconnection handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats-pure (0.1.2)
+    nats-pure (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A thread safe [Ruby](http://ruby-lang.org) client for the [NATS messaging system](https://nats.io) written in pure Ruby.
 
-[![License MIT](https://img.shields.io/npm/l/express.svg)](http://opensource.org/licenses/MIT)[![Build Status](https://travis-ci.org/wallyqs/pure-ruby-nats.svg)](http://travis-ci.org/wallyqs/pure-ruby-nats)[![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&type=5&v=0.1.2)](https://rubygems.org/gems/nats-pure/versions/0.1.2)
+[![License MIT](https://img.shields.io/npm/l/express.svg)](http://opensource.org/licenses/MIT)[![Build Status](https://travis-ci.org/wallyqs/pure-ruby-nats.svg)](http://travis-ci.org/nats-io/pure-ruby-nats)[![Gem Version](https://d25lcipzij17d.cloudfront.net/badge.svg?id=rb&type=5&v=0.1.2)](https://rubygems.org/gems/nats-pure/versions/0.1.2)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ require 'nats/io/client'
 
 nats = NATS::IO::Client.new
 
+nats.on_error do |e|
+  puts "Error: #{e}"
+end
+
 nats.on_reconnect do
   puts "Reconnected to server at #{nats.connected_server}"
 end

--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,8 @@
 - [X] TLS
 - [X] travis
 - [X] auto discovery
+- [X] gem release
 - [ ] increase test coverage
 - [ ] max payload err handling
-- [ ] gem release
 - [ ] read dynamic socket buffer
 - [ ] nuid

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -195,7 +195,7 @@ module NATS
           current[:reconnect_attempts] = 0
         rescue NoServersError => e
           @disconnect_cb.call(e) if @disconnect_cb
-          raise e
+          raise @last_err || e
         rescue => e
           # Capture sticky error
           synchronize { @last_err = e }

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -1102,7 +1102,7 @@ module NATS
 
         begin
           sock.connect_nonblock(sockaddr)
-        rescue Errno::EINPROGRESS
+        rescue Errno::EINPROGRESS, ::IO::EINPROGRESSWaitWritable
           unless ::IO.select(nil, [sock], nil, @connect_timeout)
             raise SocketTimeoutError
           end

--- a/lib/nats/io/version.rb
+++ b/lib/nats/io/version.rb
@@ -1,7 +1,7 @@
 module NATS
   module IO
     # NOTE: These are all announced to the server on CONNECT
-    VERSION  = "0.1.2"
+    VERSION  = "0.2.0"
     LANG     = "#{RUBY_ENGINE}2".freeze
     PROTOCOL = 1
   end

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -13,11 +13,25 @@ describe 'Client - Specification' do
 
   it 'should process errors from server' do
     nats = NATS::IO::Client.new
-    nats.connect
+    nats.connect(allow_reconnect: false)
+
+    mon = Monitor.new
+    done = mon.new_cond
 
     errors = []
     nats.on_error do |e|
       errors << e
+    end
+
+    disconnects = []
+    nats.on_disconnect do |e|
+      disconnects << e
+    end
+
+    closes = 0
+    nats.on_close do
+      closes += 1
+      mon.synchronize { done.signal }
     end
 
     # Trigger invalid subject server error which the client
@@ -29,9 +43,13 @@ describe 'Client - Specification' do
     nats.flush(1) rescue nil
 
     # Should have a connection closed at this without reconnecting.
-    expect(nats.closed?).to eql(true)
+    mon.synchronize { done.wait(3) }
     expect(errors.count).to eql(1)
     expect(errors.first).to be_a(NATS::IO::ServerError)
+    expect(disconnects.count).to eql(1)
+    expect(disconnects.first).to be_a(NATS::IO::ServerError)
+    expect(closes).to eql(1)
+    expect(nats.closed?).to eql(true)
   end
 
   it 'should handle unknown errors in the protocol' do
@@ -71,5 +89,73 @@ describe 'Client - Specification' do
     expect(disconnects).to eql(1)
     expect(closes).to eql(1)
     expect(nats.closed?).to eql(true)
+  end
+
+  context 'against a server which is idle' do
+    before(:all) do
+      # Start a fake tcp server
+      @fake_nats_server = TCPServer.new 4555
+      @fake_nats_server_th = Thread.new do
+        loop do
+          # Wait for a client to connect but
+          @fake_nats_server.accept
+        end
+      end
+    end
+
+    after(:all) do
+      @fake_nats_server_th.exit
+      @fake_nats_server.close
+    end
+
+    it 'should fail due to timeout errors during connect' do
+      msgs = []
+      errors = []
+      closes = 0
+      reconnects = 0
+      disconnects = []
+
+      nats = NATS::IO::Client.new
+      mon = Monitor.new
+      done = mon.new_cond
+
+      nats.on_error do |e|
+        errors << e
+      end
+
+      nats.on_reconnect do
+        reconnects += 1
+      end
+
+      nats.on_disconnect do |e|
+        disconnects << e
+      end
+
+      nats.on_close do
+        closes += 1
+        mon.synchronize { done.signal }
+      end
+
+      expect do
+      nats.connect({
+        :servers => ["nats://127.0.0.1:4555"],
+        :max_reconnect_attempts => 1,
+        :reconnect_time_wait => 1,
+        :connect_timeout => 1
+      })
+      end.to raise_error(Errno::ETIMEDOUT)
+
+      expect(disconnects.count).to eql(1)
+      expect(reconnects).to eql(0)
+      expect(closes).to eql(0)
+      expect(disconnects.last).to be_a(NATS::IO::NoServersError)
+      expect(nats.last_error).to be_a(Errno::ETIMEDOUT)
+      expect(errors.first).to be_a(Errno::ETIMEDOUT)
+      expect(errors.last).to be_a(Errno::ETIMEDOUT)
+
+      # Fails on the second reconnect attempt
+      expect(errors.count).to eql(2)
+      expect(nats.status).to eql(NATS::IO::DISCONNECTED)
+    end
   end
 end

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -97,7 +97,7 @@ describe 'Client - Specification' do
       @fake_nats_server = TCPServer.new 4555
       @fake_nats_server_th = Thread.new do
         loop do
-          # Wait for a client to connect but
+          # Wait for a client to connect and linger
           @fake_nats_server.accept
         end
       end
@@ -143,15 +143,15 @@ describe 'Client - Specification' do
         :reconnect_time_wait => 1,
         :connect_timeout => 1
       })
-      end.to raise_error(Errno::ETIMEDOUT)
+      end.to raise_error(NATS::IO::SocketTimeoutError)
 
       expect(disconnects.count).to eql(1)
       expect(reconnects).to eql(0)
       expect(closes).to eql(0)
       expect(disconnects.last).to be_a(NATS::IO::NoServersError)
-      expect(nats.last_error).to be_a(Errno::ETIMEDOUT)
-      expect(errors.first).to be_a(Errno::ETIMEDOUT)
-      expect(errors.last).to be_a(Errno::ETIMEDOUT)
+      expect(nats.last_error).to be_a(NATS::IO::SocketTimeoutError)
+      expect(errors.first).to be_a(NATS::IO::SocketTimeoutError)
+      expect(errors.last).to be_a(NATS::IO::SocketTimeoutError)
 
       # Fails on the second reconnect attempt
       expect(errors.count).to eql(2)

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -307,7 +307,7 @@ describe 'Client - Reconnect' do
       expect(closes).to eql(1)
       expect(disconnects.last).to be_a(NATS::IO::NoServersError)
       expect(nats.last_error).to be_a(NATS::IO::NoServersError)
-      expect(errors.first).to be_a(Errno::ETIMEDOUT)
+      expect(errors.first).to be_a(NATS::IO::SocketTimeoutError)
       expect(errors.last).to be_a(Errno::ECONNREFUSED)
       expect(errors.count).to eql(4)
       expect(nats.status).to eql(NATS::IO::CLOSED)

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -129,7 +129,7 @@ describe 'Client - Reconnect' do
     # Wait for a bit before checking state again
     mon.synchronize { done.wait(1) }
     expect(nats.last_error).to be_a(Errno::ECONNRESET)
-    expect(nats.status).to eql(NATS::IO::CLOSED)
+    expect(nats.status).to eql(NATS::IO::DISCONNECTED)
 
     nats.close
   end
@@ -139,7 +139,7 @@ describe 'Client - Reconnect' do
     errors = []
     closes = 0
     reconnects = 0
-    disconnects = 0
+    disconnects = []
 
     nats = NATS::IO::Client.new
     mon = Monitor.new
@@ -153,8 +153,8 @@ describe 'Client - Reconnect' do
       reconnects += 1
     end
 
-    nats.on_disconnect do
-      disconnects += 1
+    nats.on_disconnect do |e|
+      disconnects << e
     end
 
     nats.on_close do
@@ -168,7 +168,7 @@ describe 'Client - Reconnect' do
        :max_reconnect_attempts => 2,
        :reconnect_time_wait => 1
       })
-    end.to raise_error(NATS::IO::NoServersError)
+    end.to raise_error(Errno::ECONNREFUSED)
 
     # Confirm that we have captured the sticky error
     # and that the connection has remained disconnected.
@@ -183,7 +183,7 @@ describe 'Client - Reconnect' do
     errors = []
     closes = 0
     reconnects = 0
-    disconnects = 0
+    disconnects = []
 
     nats = NATS::IO::Client.new
     mon = Monitor.new
@@ -197,8 +197,8 @@ describe 'Client - Reconnect' do
       reconnects += 1
     end
 
-    nats.on_disconnect do
-      disconnects += 1
+    nats.on_disconnect do |e|
+      disconnects << e
     end
 
     nats.on_close do
@@ -232,13 +232,85 @@ describe 'Client - Reconnect' do
 
     # Confirm that we have captured the sticky error
     # and that the connection is closed due no servers left.
+    sleep 0.5
     mon.synchronize { done.wait(5) }
-    expect(disconnects).to eql(1)
+    expect(disconnects.count).to eql(2)
     expect(reconnects).to eql(0)
-    expect(closes).to eql(0)
+    expect(closes).to eql(1)
     expect(nats.last_error).to be_a(NATS::IO::NoServersError)
     expect(errors.first).to be_a(Errno::ECONNREFUSED)
     expect(errors.count).to eql(2)
     expect(nats.status).to eql(NATS::IO::CLOSED)
+  end
+
+  context 'against a server which is idle' do
+    before(:all) do
+      # Start a fake tcp server
+      @fake_nats_server = TCPServer.new 4444
+      @fake_nats_server_th = Thread.new do
+        loop do
+          # Wait for a client to connect but 
+          @fake_nats_server.accept
+        end
+      end
+    end
+
+    after(:all) do
+      @fake_nats_server_th.exit
+      @fake_nats_server.close
+    end
+
+    it 'should give up reconnecting if no servers available due to timeout errors during connect' do
+      msgs = []
+      errors = []
+      closes = 0
+      reconnects = 0
+      disconnects = []
+
+      nats = NATS::IO::Client.new
+      mon = Monitor.new
+      done = mon.new_cond
+
+      nats.on_error do |e|
+        errors << e
+      end
+
+      nats.on_reconnect do
+        reconnects += 1
+      end
+
+      nats.on_disconnect do |e|
+        disconnects << e
+      end
+
+      nats.on_close do
+        closes += 1
+        mon.synchronize { done.signal }
+      end
+
+      nats.connect({
+        :servers => ["nats://127.0.0.1:4222", "nats://127.0.0.1:4444"],
+        :max_reconnect_attempts => 1,
+        :reconnect_time_wait => 1,
+        :dont_randomize_servers => true,
+        :connect_timeout => 1
+      })
+
+      # Trigger reconnect logic
+      @s.kill_server
+
+      # Confirm that we have captured the sticky error
+      # and that the connection is closed due no servers left.
+      mon.synchronize { done.wait(7) }
+      expect(disconnects.count).to eql(2)
+      expect(reconnects).to eql(0)
+      expect(closes).to eql(1)
+      expect(disconnects.last).to be_a(NATS::IO::NoServersError)
+      expect(nats.last_error).to be_a(NATS::IO::NoServersError)
+      expect(errors.first).to be_a(Errno::ETIMEDOUT)
+      expect(errors.last).to be_a(Errno::ECONNREFUSED)
+      expect(errors.count).to eql(4)
+      expect(nats.status).to eql(NATS::IO::CLOSED)
+    end
   end
 end


### PR DESCRIPTION
- Fix last error shadowing on connection failures (originally reported at https://github.com/wallyqs/pure-ruby-nats/pull/5 )

- Follow more closely behavior from the Go client on connect failures

- Add customizable `:connect_timeout`

- Add read timeouts for read line during `CONNECTING` and `RECONNECTING` stages

- Add `SocketTimeoutError` to represent i/o timeout errors with socket