### PR TITLE
Add auth token support

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -616,8 +616,12 @@ module NATS
         cs[:name] = @options[:name] if @options[:name]
 
         if auth_connection?
-          cs[:user] = @uri.user
-          cs[:pass] = @uri.password
+          if @uri.password
+            cs[:user] = @uri.user
+            cs[:pass] = @uri.password
+          else
+            cs[:auth_token] = @uri.user
+          end
         end
 
         "CONNECT #{cs.to_json}#{CR_LF}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,8 +65,13 @@ class NatsServerControl
     @pid = nil
 
     args = "-p #{@uri.port} -P #{@pid_file}"
-    args += " --user #{@uri.user}" if @uri.user
-    args += " --pass #{@uri.password}" if @uri.password
+
+    if @uri.user && !@uri.password
+      args += " --auth #{@uri.user}"
+    else
+      args += " --user #{@uri.user}" if @uri.user
+      args += " --pass #{@uri.password}" if @uri.password
+    end
     args += " #{@flags}" if @flags
 
     if ENV["DEBUG_NATS_TEST"] == "true"


### PR DESCRIPTION
Prevents Authorization Error when you attempt to connect to a gnatsd
server with an authorization token instead of user:pass.

Added test to auth spec