### PR TITLE
Fixes to unknown protocol error handling and reconnections

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -897,6 +897,10 @@ module NATS
         @status = CONNECTED
         @pending_size = 0
 
+        # Reset parser state here to avoid unknown protocol errors
+        # on reconnect...
+        @parser.reset!
+
         # Now connected to NATS, and we can restart parser loop, flusher
         # and ping interval
         start_threads!

--- a/lib/nats/io/parser.rb
+++ b/lib/nats/io/parser.rb
@@ -24,8 +24,11 @@ module NATS
     class Parser
       def initialize(nc)
         @nc = nc
+        reset!
+      end
+
+      def reset!
         @buf = nil
-        @needed = nil
         @parse_state = AWAITING_CONTROL_LINE
 
         @sub = nil

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -13,7 +13,7 @@ describe 'Client - Specification' do
 
   it 'should process errors from server' do
     nats = NATS::IO::Client.new
-    nats.connect(allow_reconnect: false)
+    nats.connect(reconnect: false)
 
     mon = Monitor.new
     done = mon.new_cond
@@ -42,7 +42,7 @@ describe 'Client - Specification' do
     # disconnection may have already occurred.
     nats.flush(1) rescue nil
 
-    # Should have a connection closed at this without reconnecting.
+    nats.close
     mon.synchronize { done.wait(3) }
     expect(errors.count).to eql(1)
     expect(errors.first).to be_a(NATS::IO::ServerError)

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -57,7 +57,7 @@ describe 'Client - Specification' do
     done = mon.new_cond
 
     nats = NATS::IO::Client.new
-    nats.connect
+    nats.connect(reconnect: false)
 
     errors = []
     nats.on_error do |e|
@@ -88,6 +88,7 @@ describe 'Client - Specification' do
     expect(errors.first.to_s).to include("Unknown protocol")
     expect(disconnects).to eql(1)
     expect(closes).to eql(1)
+
     expect(nats.closed?).to eql(true)
   end
 

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -301,10 +301,8 @@ describe 'Client - Reconnect' do
 
       # Trigger reconnect logic
       @s.kill_server
-
-      # Confirm that we have captured the sticky error
-      # and that the connection is closed due no servers left.
       mon.synchronize { done.wait(7) }
+
       expect(disconnects.count).to eql(2)
       expect(reconnects).to eql(0)
       expect(closes).to eql(1)
@@ -386,9 +384,6 @@ describe 'Client - Reconnect' do
         :connect_timeout => 1,
         :ping_interval => 2
       })
-
-      # Confirm that we have captured the sticky error
-      # and that the connection is closed due no servers left.
       mon.synchronize { done.wait(7) }
 
       # Wrap up connection with server and confirm
@@ -400,6 +395,93 @@ describe 'Client - Reconnect' do
       expect(errors.count).to eql(1)
       expect(errors.first).to be_a(NATS::IO::StaleConnectionError)
       expect(nats.last_error).to eql(nil)
+      expect(nats.status).to eql(NATS::IO::CLOSED)
+    end
+  end
+
+  context 'against a server which stops following protocol after being connected' do
+    before(:all) do
+      # Start a fake tcp server
+      @fake_nats_server = TCPServer.new 4446
+      @fake_nats_server_th = Thread.new do
+        loop do
+          # Wait for a client to connect
+          client = @fake_nats_server.accept
+          begin
+            client.puts "INFO {}"
+
+            # Read and ignore CONNECT command send by the client
+            connect_op = client.gets.chomp
+
+            # Reply to any pending pings client may have sent
+            sleep 0.1
+            client.puts "PONG\r\n"
+            sleep 1
+
+            client.puts "MSG MSG MSG MSG\r\n"
+            sleep 10
+          ensure
+            client.close
+          end
+        end
+      end
+    end
+
+    after(:all) do
+      @fake_nats_server_th.exit
+      @fake_nats_server.close
+    end
+
+    it 'should reconnect to a healthy server after unknown protocol error' do
+      msgs = []
+      errors = []
+      closes = 0
+      reconnects = 0
+      disconnects = 0
+
+      nats = NATS::IO::Client.new
+      mon = Monitor.new
+      done = mon.new_cond
+
+      nats.on_error do |e|
+        errors << e
+      end
+
+      nats.on_reconnect do
+        reconnects += 1
+      end
+
+      nats.on_disconnect do
+        disconnects += 1
+        mon.synchronize { done.signal }
+      end
+
+      nats.on_close do
+        closes += 1
+      end
+
+      nats.connect({
+        :servers => ["nats://127.0.0.1:4446","nats://127.0.0.1:4222"],
+        :max_reconnect_attempts => -1,
+        :reconnect_time_wait => 2,
+        :dont_randomize_servers => true,
+        :connect_timeout => 1
+      })
+      # Wait for disconnect due to the unknown protocol error
+      mon.synchronize { done.wait(7) }
+      expect(errors.first).to be_a(NATS::IO::ServerError)
+      expect(errors.first.to_s).to include("Unknown protocol")
+
+      # Wait a bit for reconnect to occur
+      sleep 1
+      expect(nats.status).to eql(NATS::IO::CONNECTED)
+      expect(disconnects).to eql(1)
+      expect(reconnects).to eql(1)
+      expect(closes).to eql(0)
+      expect(errors.count).to eql(1)
+
+      # Wrap up connection with server and confirm
+      nats.close
       expect(nats.status).to eql(NATS::IO::CLOSED)
     end
   end


### PR DESCRIPTION
When dealing with unhealthy connections or servers which are not following the protocol for some reason, change to trigger a reconnection rather than giving up connecting altogether.
This also fixes resetting the state of the protocol parser upon reconnection which was resulting in unknown protocol errors as well due to previous state.