### PR TITLE
Use IO::WaitReadable and IO::WaitWritable errors only

### DIFF
--- a/examples/clustered.rb
+++ b/examples/clustered.rb
@@ -26,8 +26,9 @@ cluster_opts = {
   servers: servers,
   reconnect_time_wait: 1,
   max_reconnect_attempts: -1, # Infinite reconnects
-  ping_interval: 30,
-  dont_randomize_servers: true
+  ping_interval: 10,
+  dont_randomize_servers: true,
+  connect_timeout: 2
 }
 
 puts "Attempting to connect to #{servers.first}..."


### PR DESCRIPTION
Ruby already mixes `Errno::EWOULDBLOCK` or `Errno::EAGAIN` type of errors into these anyway.

Originally reported at https://github.com/wallyqs/pure-ruby-nats/issues/6

> If a Ruby platform supports IO::WaitReadable and IO::WaitWritable, those should be the only exceptions rescued. This is because ruby extends the original error (could be either Errno::EWOULDBLOCK or Errno::EAGAIN) with IO::WaitReadable or IO::WaitWritable. If IO::WaitWritable is raised in your NATS::IO::Socket#read, the first rescue will still be the only one triggered because the original error that has been extended is still an Errno::EWOULDBLOCK or Errno::EAGAIN. The same situation occurs if a IO::WaitReadable is raised in NATS::IO::Socket#write.
> 
> RE: redis/redis-rb#649
> RE: https://github.com/ruby/ruby/blob/09ae127bade1d58705adfccb09a70403d8d909d5/io.c#L12346-L12349
> RE: https://github.com/ruby/ruby/blob/09ae127bade1d58705adfccb09a70403d8d909d5/io.c#L12351-L12354
> 