### PR TITLE
Add synchronize around @subs and @ssid

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -264,8 +264,8 @@ module NATS
       # Create subscription which is dispatched asynchronously
       # messages to a callback.
       def subscribe(subject, opts={}, &callback)
-        sid = (@ssid += 1)
-        sub = @subs[sid] = Subscription.new
+        sid = synchronize { @ssid += 1 }
+        sub = synchronize { @subs[sid] = Subscription.new }
         sub.subject = subject
         sub.callback = callback
         sub.received = 0
@@ -437,7 +437,7 @@ module NATS
               return
             when sub.received == sub.max
               # Cleanup here if we have hit the max..
-              @subs.delete(sid)
+              synchronize { @subs.delete(sid) }
             end
           end
 

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -264,8 +264,12 @@ module NATS
       # Create subscription which is dispatched asynchronously
       # messages to a callback.
       def subscribe(subject, opts={}, &callback)
-        sid = synchronize { @ssid += 1 }
-        sub = synchronize { @subs[sid] = Subscription.new }
+        sid = nil
+        sub = nil
+        synchronize do
+          sid = (@ssid += 1)
+          sub = @subs[sid] = Subscription.new
+        end
         sub.subject = subject
         sub.callback = callback
         sub.received = 0

--- a/spec/client_tls_spec.rb
+++ b/spec/client_tls_spec.rb
@@ -130,7 +130,7 @@ describe 'Client - TLS spec' do
 
       expect do
         tls_context = OpenSSL::SSL::SSLContext.new
-        tls_context.ssl_version = :SSLv3
+        tls_context.ssl_version = :TLSv1
 
         nats.connect({
                        servers: ['tls://127.0.0.1:4444'],


### PR DESCRIPTION
This fixes thread-safety issues around `@subs` and `@ssid` when using JRuby.

Not sure what the cost is of having 2 vs. 1 `synchronize` call in the `subscribe` method. Happy to roll that up into one.