### PR TITLE
Add delivery thread per async subscriber

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats-pure (0.3.0)
+    nats-pure (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -323,11 +323,17 @@ module NATS
               cb = sub.callback
             end
 
-            case cb.arity
-            when 0 then cb.call
-            when 1 then cb.call(msg.data)
-            when 2 then cb.call(msg.data, msg.reply)
-            else cb.call(msg.data, msg.reply, msg.subject)
+            begin
+              case cb.arity
+              when 0 then cb.call
+              when 1 then cb.call(msg.data)
+              when 2 then cb.call(msg.data, msg.reply)
+              else cb.call(msg.data, msg.reply, msg.subject)
+              end
+            rescue => e
+              synchronize do
+                @err_cb.call(e) if @err_cb
+              end
             end
           end
         end

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -39,6 +39,10 @@ module NATS
     DEFAULT_CONNECT_TIMEOUT = 2
     DEFAULT_READ_WRITE_TIMEOUT = 2
 
+    # Default Pending Limits
+    DEFAULT_SUB_PENDING_MSGS_LIMIT  = 65536
+    DEFAULT_SUB_PENDING_BYTES_LIMIT = 65536 * 1024
+
     CR_LF = ("\r\n".freeze)
     CR_LF_SIZE = (CR_LF.bytesize)
 
@@ -286,17 +290,47 @@ module NATS
           sid = (@ssid += 1)
           sub = @subs[sid] = Subscription.new
         end
+        opts[:pending_msgs_limit]  ||= DEFAULT_SUB_PENDING_MSGS_LIMIT
+        opts[:pending_bytes_limit] ||= DEFAULT_SUB_PENDING_BYTES_LIMIT
+
         sub.subject = subject
         sub.callback = callback
         sub.received = 0
         sub.queue = opts[:queue] if opts[:queue]
         sub.max = opts[:max] if opts[:max]
+        sub.pending_msgs_limit  = opts[:pending_msgs_limit]
+        sub.pending_bytes_limit = opts[:pending_bytes_limit]
+        sub.pending_queue = SizedQueue.new(sub.pending_msgs_limit)
 
         send_command("SUB #{subject} #{opts[:queue]} #{sid}#{CR_LF}")
         @flush_queue << :sub
 
         # Setup server support for auto-unsubscribe when receiving enough messages
         unsubscribe(sid, opts[:max]) if opts[:max]
+
+        # Async subscriptions each own a single thread for the
+        # delivery of messages.
+        # FIXME: Support shared thread pool with configurable limits
+        # to better support case of having a lot of subscriptions.
+        sub.wait_for_msgs_t = Thread.new do
+          loop do
+            msg = sub.pending_queue.pop
+
+            cb = nil
+            sub.synchronize do
+              # Decrease pending size since consumed already
+              sub.pending_size -= msg.data.size
+              cb = sub.callback
+            end
+
+            case cb.arity
+            when 0 then cb.call
+            when 1 then cb.call(msg.data)
+            when 2 then cb.call(msg.data, msg.reply)
+            else cb.call(msg.data, msg.reply, msg.subject)
+            end
+          end
+        end
 
         sid
       end
@@ -369,6 +403,12 @@ module NATS
         synchronize do
           sub.max = opt_max
           @subs.delete(sid) unless (sub.max && (sub.received < sub.max))
+
+          # Stop messages delivery thread for async subscribers
+          if sub.wait_for_msgs_t && sub.wait_for_msgs_t.alive?
+            sub.wait_for_msgs_t.exit
+            sub.pending_queue.clear
+          end
         end
       end
 
@@ -446,9 +486,10 @@ module NATS
         synchronize { sub = @subs[sid] }
         return unless sub
 
-        # Check for auto_unsubscribe
         sub.synchronize do
           sub.received += 1
+
+          # Check for auto_unsubscribe
           if sub.max
             case
             when sub.received > sub.max
@@ -469,18 +510,11 @@ module NATS
             future.signal
 
             return
-          end
-        end
-
-        # Distinguish between async subscriptions with callbacks
-        # and request subscriptions which expect a single response.
-        if sub.callback
-          cb = sub.callback
-          case cb.arity
-          when 0 then cb.call
-          when 1 then cb.call(data)
-          when 2 then cb.call(data, reply)
-          else cb.call(data, reply, subject)
+          elsif sub.callback
+            # Async subscribers use a sized queue for processing
+            # and should be able to consume messages in parallel.
+            sub.pending_queue << Msg.new(subject, reply, data)
+            sub.pending_size += data.size
           end
         end
       end
@@ -998,7 +1032,15 @@ module NATS
             @err_cb.call(e) if @err_cb
           end if should_flush
 
-          # TODO: Destroy any remaining subscriptions
+          # Destroy any remaining subscriptions.
+          @subs.each do |_, sub|
+            if sub.wait_for_msgs_t && sub.wait_for_msgs_t.alive?
+              sub.wait_for_msgs_t.exit
+              sub.pending_queue.clear
+            end
+          end
+          @subs.clear
+
           if do_cbs
             @disconnect_cb.call(@last_err) if @disconnect_cb
             @close_cb.call if @close_cb
@@ -1195,7 +1237,9 @@ module NATS
   class Subscription
     include MonitorMixin
 
-    attr_accessor :subject, :queue, :future, :callback, :response, :received, :max
+    attr_accessor :subject, :queue, :future, :callback, :response, :received, :max, :pending
+    attr_accessor :pending_queue, :pending_size, :wait_for_msgs_t, :is_slow_consumer
+    attr_accessor :pending_msgs_limit, :pending_bytes_limit
 
     def initialize
       super # required to initialize monitor
@@ -1206,6 +1250,15 @@ module NATS
       @response = nil
       @received = 0
       @max      = nil
+      @pending  = nil
+
+      # State from async subscriber messages delivery
+      @pending_queue       = nil
+      @pending_size        = 0
+      @pending_msgs_limit  = nil
+      @pending_bytes_limit = nil
+      @wait_for_msgs_t     = nil
+      @is_slow_consumer    = false
     end
   end
 

--- a/lib/nats/io/version.rb
+++ b/lib/nats/io/version.rb
@@ -1,7 +1,7 @@
 module NATS
   module IO
     # NOTE: These are all announced to the server on CONNECT
-    VERSION  = "0.3.0"
+    VERSION  = "0.4.0"
     LANG     = "#{RUBY_ENGINE}2".freeze
     PROTOCOL = 1
   end

--- a/spec/client_cluster_reconnect_spec.rb
+++ b/spec/client_cluster_reconnect_spec.rb
@@ -139,9 +139,9 @@ describe 'Client - Cluster reconnect' do
 
       nats = NATS::IO::Client.new
       nats.connect({
-                     servers: [@s1.uri, @s2.uri],
-                     dont_randomize_servers: true
-                   })
+        servers: [@s1.uri, @s2.uri],
+        dont_randomize_servers: true
+      })
 
       disconnects = 0
       nats.on_disconnect do |e|
@@ -179,6 +179,9 @@ describe 'Client - Cluster reconnect' do
         case
         when n == 100
           nats.flush
+
+          # Wait a bit for all messages
+          sleep 0.5
           expect(msgs.count).to eql(100)
           @s1.kill_server
         when (n % 100 == 0)

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -128,13 +128,16 @@ describe 'Client - Specification' do
         raise CustomError.new("NG!")
       end
 
-      msgs << payload      
+      msgs << payload
     end
 
     5.times do
       nats.publish("hello")
     end
     nats.flush(1) rescue nil
+
+    # Wait for messages to be received
+    sleep 2
 
     nats.close
     mon.synchronize { done.wait(3) }
@@ -146,7 +149,119 @@ describe 'Client - Specification' do
     expect(disconnects.first).to be_nil
     expect(closes).to eql(1)
     expect(nats.closed?).to eql(true)
-  end  
+  end
+
+  it 'should handle subscriptions with slow consumers as async errors when over pending msgs limit' do
+    nats = NATS::IO::Client.new
+    nats.connect(reconnect: false)
+
+    mon = Monitor.new
+    done = mon.new_cond
+
+    errors = []
+    nats.on_error do |e|
+      errors << e
+    end
+
+    disconnects = []
+    nats.on_disconnect do |e|
+      disconnects << e
+    end
+
+    closes = 0
+    nats.on_close do
+      closes += 1
+      mon.synchronize { done.signal }
+    end
+
+    msgs = []
+    nats.subscribe("hello", pending_msgs_limit: 5) do |payload|
+      msgs << payload
+      sleep 1 if msgs.count == 5
+    end
+
+    20.times do |n|
+      nats.publish("hello", "ng-#{n}")
+    end
+    nats.flush(1) rescue nil
+
+    # Wait a bit for subscriber to recover
+    sleep 2
+    3.times do |n|
+      nats.publish("hello", "ok-#{n}")
+    end
+    nats.flush(1) rescue nil
+
+    # Wait a bit to receive final messages
+    sleep 0.5
+
+    nats.close
+    mon.synchronize { done.wait(3) }
+
+    # Should have dropped some messages but include the last few
+    3.times do |n|
+      expect(msgs.include?("ok-#{n}")).to eql(true)
+    end
+    expect(errors.first).to be_a(NATS::IO::SlowConsumer)
+    expect(disconnects.count).to eql(1)
+    expect(disconnects.first).to be_a(NATS::IO::SlowConsumer)
+    expect(closes).to eql(1)
+    expect(nats.closed?).to eql(true)
+  end
+
+  it 'should handle subscriptions with slow consumers as async errors when over pending bytes limit' do
+    nats = NATS::IO::Client.new
+    nats.connect(reconnect: false)
+
+    mon = Monitor.new
+    done = mon.new_cond
+
+    errors = []
+    nats.on_error do |e|
+      errors << e
+    end
+
+    disconnects = []
+    nats.on_disconnect do |e|
+      disconnects << e
+    end
+
+    closes = 0
+    nats.on_close do
+      closes += 1
+      mon.synchronize { done.signal }
+    end
+
+    data = ''
+    nats.subscribe("hello", pending_bytes_limit: 10) do |payload|
+      data += payload
+      sleep 2 if data.size == 10
+    end
+
+    20.times do
+      nats.publish("hello", 'A')
+    end
+    nats.flush(1) rescue nil
+    sleep 2
+
+    3.times do |n|
+      nats.publish("hello", 'B')
+    end
+    nats.flush(1) rescue nil
+
+    # Wait a bit to receive final messages
+    sleep 0.5
+
+    nats.close
+    mon.synchronize { done.wait(3) }
+
+    # Should have dropped a few messages
+    expect(errors.first).to be_a(NATS::IO::SlowConsumer)
+    expect(disconnects.count).to eql(1)
+    expect(disconnects.first).to be_a(NATS::IO::SlowConsumer)
+    expect(closes).to eql(1)
+    expect(nats.closed?).to eql(true)
+  end
 
   context 'against a server which is idle' do
     before(:all) do

--- a/spec/client_errors_spec.rb
+++ b/spec/client_errors_spec.rb
@@ -92,6 +92,62 @@ describe 'Client - Specification' do
     expect(nats.closed?).to eql(true)
   end
 
+  it 'should handle as async errors uncaught exceptions from callbacks' do
+    nats = NATS::IO::Client.new
+    nats.connect(reconnect: false)
+
+    mon = Monitor.new
+    done = mon.new_cond
+
+    errors = []
+    nats.on_error do |e|
+      errors << e
+    end
+
+    disconnects = []
+    nats.on_disconnect do |e|
+      disconnects << e
+    end
+
+    closes = 0
+    nats.on_close do
+      closes += 1
+      mon.synchronize { done.signal }
+    end
+
+    # Trigger invalid subject server error which the client
+    # detects so that it will disconnect
+    class CustomError < StandardError; end
+
+    n = 0
+    msgs = []
+    nats.subscribe("hello") do |payload|
+      n += 1
+
+      if n == 2
+        raise CustomError.new("NG!")
+      end
+
+      msgs << payload      
+    end
+
+    5.times do
+      nats.publish("hello")
+    end
+    nats.flush(1) rescue nil
+
+    nats.close
+    mon.synchronize { done.wait(3) }
+
+    expect(msgs.count).to eql(4)
+    expect(errors.count).to eql(1)
+    expect(errors.first).to be_a(CustomError)
+    expect(disconnects.count).to eql(1)
+    expect(disconnects.first).to be_nil
+    expect(closes).to eql(1)
+    expect(nats.closed?).to eql(true)
+  end  
+
   context 'against a server which is idle' do
     before(:all) do
       # Start a fake tcp server

--- a/spec/client_threadsafe_spec.rb
+++ b/spec/client_threadsafe_spec.rb
@@ -30,12 +30,14 @@ describe 'Client - Thread safety' do
     component = Component.new
     component.connect!
 
+    threads = []
     thr_a = Thread.new do
       component.nats.subscribe("hello") do |data, reply, subject|
         component.msgs << { :data => data, :subject => subject }
       end
       sleep 0.01 until component.msgs.count > 100
     end
+    threads << thr_a
 
     thr_b = Thread.new do
       component.nats.subscribe("world") do |data, reply, subject|
@@ -43,6 +45,7 @@ describe 'Client - Thread safety' do
       end
       sleep 0.01 until component.msgs.count > 100
     end
+    threads << thr_b
 
     # More than enough for subscriptions to have been flushed already.
     sleep 1
@@ -53,6 +56,7 @@ describe 'Client - Thread safety' do
       end
       component.nats.flush
     end
+    threads << thr_c
 
     thr_d = Thread.new do
       (0..99).step(2) do |n|
@@ -60,6 +64,7 @@ describe 'Client - Thread safety' do
       end
       component.nats.flush
     end
+    threads << thr_d
 
     sleep 1
     expect(component.msgs.count).to eql(100)
@@ -75,5 +80,62 @@ describe 'Client - Thread safety' do
 
     result = component.msgs.select { |msg| msg[:subject] == "world" && msg[:data].to_i % 2 == 0 }
     expect(result.count).to eql(50)
+
+    component.nats.close
+
+    threads.each do |t|
+      t.kill
+    end
+  end
+
+  it 'should allow async subscriptions to process messages in parallel' do
+    nc = NATS::IO::Client.new
+    nc.connect(servers: ['nats://0.0.0.0:4222'])
+
+    foo_msgs = []
+    nc.subscribe('foo') do |payload|
+      foo_msgs << payload
+      sleep 1
+    end
+
+    bar_msgs = []
+    nc.subscribe('bar') do |payload, reply|
+      bar_msgs << payload
+      nc.publish(reply, 'OK!')
+    end
+
+    quux_msgs = []
+    nc.subscribe('quux') do |payload, reply|
+      quux_msgs << payload
+    end
+
+    # Receive on message foo first which takes longer to process.
+    nc.publish('foo', 'hello')
+
+    # Publish many messages to quux which should be able to consume fast.
+    1.upto(10).each do |n|
+      nc.publish('quux', "test-#{n}")      
+    end
+
+    # Awaiting for the response happens on the same
+    # thread where the request is happening, then
+    # the read loop thread is going to signal back.
+    response = nil
+    expect do
+      response = nc.request('bar', 'help', timeout: 0.5)
+    end.to_not raise_error
+
+    expect(response.data).to eql('OK!')
+
+    # Wait a bit in case all of this happened too fast
+    sleep 0.2
+    expect(foo_msgs.count).to eql(1)
+    expect(bar_msgs.count).to eql(1)
+    expect(quux_msgs.count).to eql(10)
+
+    1.upto(10).each do |n|
+      expect(quux_msgs[n-1]).to eql("test-#{n}")
+    end
+    nc.close
   end
 end


### PR DESCRIPTION
Current implementation means that multiple subscribers are not able to process messages in parallel so causing head of line blocking issues among each other.

Now each async subscriber has its own thread and a sized queue for message delivery in order to avoid this, following similar usage as in the Go client where a goroutine is used per Subscription.