### PR TITLE
Updated Request/Response implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats-pure (0.4.0)
+    nats-pure (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -173,13 +173,19 @@ module NATS
         # Hostname of current server; used for when TLS host
         # verification is enabled.
         @hostname = nil
+
+        # New style request/response implementation.
+        @resp_sub = nil
+        @resp_map = nil
+        @resp_sub_prefix = nil
       end
 
-      # Establishes connection to NATS
+      # Establishes connection to NATS.
       def connect(opts={})
         opts[:verbose] = false if opts[:verbose].nil?
         opts[:pedantic] = false if opts[:pedantic].nil?
         opts[:reconnect] = true if opts[:reconnect].nil?
+        opts[:old_style_request] = false if opts[:old_style_request].nil?
         opts[:reconnect_time_wait] = RECONNECT_TIME_WAIT if opts[:reconnect_time_wait].nil?
         opts[:max_reconnect_attempts] = MAX_RECONNECT_ATTEMPTS if opts[:max_reconnect_attempts].nil?
         opts[:ping_interval] = DEFAULT_PING_INTERVAL if opts[:ping_interval].nil?
@@ -194,9 +200,6 @@ module NATS
         opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
         opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?
         opts[:connect_timeout] ||= DEFAULT_CONNECT_TIMEOUT
-
-        # TODO: Make new style default instead.
-        opts[:old_style_request] = true if opts[:old_style_request].nil?
         @options = opts
 
         # Process servers in the NATS cluster and pick one to connect
@@ -374,7 +377,43 @@ module NATS
       # If given a callback, then the request happens asynchronously.
       def request(subject, payload, opts={}, &blk)
         return unless subject
-        old_request(subject, payload, opts, &blk)
+
+        # If a block was given then fallback to method using auto unsubscribe.
+        return old_request(subject, payload, opts, &blk) if blk
+
+        token = nil
+        inbox = nil
+        future = nil
+        response = nil
+        timeout = opts[:timeout] ||= 0.5
+        synchronize do
+          start_resp_mux_sub! unless @resp_sub_prefix
+
+          # Create token for this request.
+          token = SecureRandom.hex(11)
+          inbox = "#{@resp_sub_prefix}.#{token}"
+
+          # Create the a future for the request that will
+          # get signaled when it receives the request.
+          future = @resp_sub.new_cond
+          @resp_map[token][:future] = future
+        end
+
+        # Publish request and wait for reply.
+        publish(subject, payload, inbox)
+        with_nats_timeout(timeout) do
+          @resp_sub.synchronize do
+            future.wait(timeout)
+          end
+        end
+
+        # Check if there is a response already
+        synchronize do
+          result = @resp_map[token]
+          response = result[:response]
+        end
+
+        response
       end
 
       # Sends a request creating an ephemeral subscription for the request,
@@ -554,7 +593,7 @@ module NATS
             future.signal
 
             return
-          elsif sub.callback
+          elsif sub.pending_queue
             # Async subscribers use a sized queue for processing
             # and should be able to consume messages in parallel.
             if sub.pending_queue.size >= sub.pending_msgs_limit \
@@ -1125,6 +1164,47 @@ module NATS
         # Ping interval handling for keeping alive the connection
         @ping_interval_thread = Thread.new { ping_interval_loop }
         @ping_interval_thread.abort_on_exception = true
+      end
+
+      # Prepares requests subscription that handles the responses
+      # for the new style request response.
+      def start_resp_mux_sub!
+        @resp_sub_prefix = "_INBOX.#{SecureRandom.hex(11)}"
+        @resp_map = Hash.new { |h,k| h[k] = { }}
+
+        @resp_sub = Subscription.new
+        @resp_sub.subject = "#{@resp_sub_prefix}.*"
+        @resp_sub.received = 0
+
+        # FIXME: Allow setting pending limits for responses mux subscription.
+        @resp_sub.pending_msgs_limit = DEFAULT_SUB_PENDING_MSGS_LIMIT
+        @resp_sub.pending_bytes_limit = DEFAULT_SUB_PENDING_BYTES_LIMIT
+        @resp_sub.pending_queue = SizedQueue.new(@resp_sub.pending_msgs_limit)
+        @resp_sub.wait_for_msgs_t = Thread.new do
+          loop do
+            msg = @resp_sub.pending_queue.pop
+            @resp_sub.pending_size -= msg.data.size
+
+            # Pick the token and signal the request under the mutex
+            # from the subscription itself.
+            token = msg.subject.split('.').last
+            future = nil
+            synchronize do
+              future = @resp_map[token][:future]
+              @resp_map[token][:response] = msg
+            end
+
+            # Signal back that the response has arrived.
+            @resp_sub.synchronize do
+              future.signal
+            end
+          end
+        end
+
+        sid = (@ssid += 1)
+        @subs[sid] = @resp_sub
+        send_command("SUB #{@resp_sub.subject} #{sid}#{CR_LF}")
+        @flush_queue << :sub
       end
 
       def can_reuse_server?(server)

--- a/lib/nats/io/version.rb
+++ b/lib/nats/io/version.rb
@@ -15,7 +15,7 @@
 module NATS
   module IO
     # NOTE: These are all announced to the server on CONNECT
-    VERSION  = "0.4.0"
+    VERSION  = "0.5.0"
     LANG     = "#{RUBY_ENGINE}2".freeze
     PROTOCOL = 1
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -186,52 +186,6 @@ describe 'Client - Specification' do
     nc.close
   end
 
-  it 'should be able to receive response to requests' do
-    mon = Monitor.new
-    subscribed_done = mon.new_cond
-    test_done = mon.new_cond
-
-    another_thread = Thread.new do
-      nats = NATS::IO::Client.new
-      nats.connect(:servers => [@s.uri], :reconnect => false)
-      nats.subscribe("help") do |msg, reply|
-        nats.publish(reply, "I can help")
-      end
-      nats.flush
-      mon.synchronize do
-        subscribed_done.signal
-      end
-      mon.synchronize do
-        test_done.wait(1)
-        nats.close
-      end
-    end
-
-    nc = NATS::IO::Client.new
-    nc.connect(:servers => [@s.uri])
-    mon.synchronize do
-      subscribed_done.wait(1)
-    end
-
-    responses = []
-    expect do
-      3.times do
-        responses << nc.request("help", "please", timeout: 1)
-      end
-    end.to_not raise_error
-    expect(responses.count).to eql(3)
-
-    # A new subscription would have the next sid for this client
-    sid = nc.subscribe("hello"){}
-    expect(sid).to eql(4)
-    mon.synchronize do
-      test_done.signal
-    end
-
-    nc.close
-    another_thread.exit
-  end
-
   it 'should close connection gracefully' do
     mon = Monitor.new
     test_is_done = mon.new_cond
@@ -346,6 +300,116 @@ describe 'Client - Specification' do
       expect(responses.last[:data]).to eql('reply.2')
 
       nc.close
+    end
+
+    it 'should be able to receive requests synchronously in parallel' do
+      nc = NATS::IO::Client.new
+      nc.connect(:servers => [@s.uri], :old_style_request => false)
+
+      received = []
+      nc.subscribe("help") do |payload, reply, subject|
+        # Echoes the same data back.
+        nc.publish(reply, payload)
+      end
+      nc.flush
+
+      total = 100
+      responses_a = []
+      t_a = Thread.new do
+        sleep 0.2
+        total.times do |n|
+          responses_a << nc.request("help", "please-A-#{n}", timeout: 0.5)
+        end
+      end
+
+      responses_b = []
+      t_b = Thread.new do
+        sleep 0.2
+        total.times do |n|
+          responses_b << nc.request("help", "please-B-#{n}", timeout: 0.5)
+        end
+      end
+
+      responses_c = []
+      t_c = Thread.new do
+        sleep 0.2
+        total.times do |n|
+          responses_c << nc.request("help", "please-C-#{n}", timeout: 0.5)
+        end
+      end
+
+      sleep 1
+      expect(responses_a.count).to eql(total)
+      expect(responses_b.count).to eql(total)
+      expect(responses_c.count).to eql(total)
+
+      n = 0
+      responses_a.each do |msg|
+        expect(msg.data).to eql("please-A-#{n}")
+        n += 1
+      end
+
+      n = 0
+      responses_b.each do |msg|
+        expect(msg.data).to eql("please-B-#{n}")
+        n += 1
+      end
+
+      n = 0
+      responses_c.each do |msg|
+        expect(msg.data).to eql("please-C-#{n}")
+        n += 1
+      end
+
+      nc.close
+    end
+  end
+
+  context "using old style request" do
+    it 'should be able to receive responses' do
+      mon = Monitor.new
+      subscribed_done = mon.new_cond
+      test_done = mon.new_cond
+
+      another_thread = Thread.new do
+        nats = NATS::IO::Client.new
+        nats.connect(:servers => [@s.uri], :reconnect => false)
+        nats.subscribe("help") do |msg, reply|
+          nats.publish(reply, "I can help")
+        end
+        nats.flush
+        mon.synchronize do
+          subscribed_done.signal
+        end
+        mon.synchronize do
+          test_done.wait(1)
+          nats.close
+        end
+      end
+
+      nc = NATS::IO::Client.new
+      nc.connect(:servers => [@s.uri], :old_style_request => true)
+      mon.synchronize do
+        subscribed_done.wait(1)
+      end
+
+      responses = []
+      expect do
+        3.times do
+          responses << nc.request("help", "please", timeout: 1)
+        end
+      end.to_not raise_error
+      expect(responses.count).to eql(3)
+
+      # A new subscription would have the next sid for this client.
+      sid = nc.subscribe("hello"){}
+      expect(sid).to eql(4)
+      mon.synchronize do
+        test_done.signal
+      end
+
+      nc.close
+      another_thread.exit
     end
   end
 end


### PR DESCRIPTION
Port of the current implementation of request/response from the Go client, where a single subscription with a wildcard is responsible of handling the responses, making it the default implementation.
In order to revert to previous implementation, the `old_style_request` option can be passed on initial connect.

```ruby
nc.connect(servers: ["nats://demo.nats.io:4222"], old_style_request: true)
```
